### PR TITLE
Improve mount for chroot and T100CHI keyboard pairing

### DIFF
--- a/T100TA_guide.md
+++ b/T100TA_guide.md
@@ -2,7 +2,7 @@
 
 # Installing Ubuntu on ASUS T100 TA
 
-As of November 2018. (20181125)
+As of February 2019. (20190221)
 
 John Brodie said
 > The problem with step by step guides. The information is only accurate for up to a few months.
@@ -148,7 +148,7 @@ Note: Alternatively, if you know what you are doing, you can create a new partit
 Now, you should be able to connect your ASUS T100 to your network.
 
 #### Chroot in the new system
-- Find the EFI System Partition. This should be the VFAT partition next to `/target`
+- Find the EFI System Partition. This should be the VFAT partition next to the EXT4 partition
   * In the example below, it is `mmcblk2p1`
   * If you are unsure, check its size with `lsblk`, it should be about 100M.
   * `lsblk -f`
@@ -168,12 +168,14 @@ mmcblk2boot1
 mmcblk0
 └─mmcblk0p1  vfat                 9016-4EF8             /media/xubuntu/9016-4EF8
 ```
+- If your ext4 partition is not mounted, you must do it
+  * `mount /dev/mmcblk2p2 /target`
 - Mount the EFI System Partition on the new system
   * `mount /dev/mmcblk2p1 /target/boot/efi`
 - Then, we have to mount some other filesystems before chrooting:
 ```
 for dir in /dev /dev/pts /proc /run /sys;
-  do mount --bind "$dir" /target/"$dir";
+  do mount --bind "$dir" /target"$dir";
 done
 ```
 - Here we go!
@@ -297,6 +299,8 @@ With hardware video decoding, a video player should use around 25% CPU when play
 ### 14. Bluetooth
 /!\ Same warning as Sound and WiFi, the following file is for T100TA and T100CHI only. Other T100's (T100TAF and T100H\*) have other Bluetooth device numbers.
 
+/!\ On T100CHI, to get keyboard working, boot with docking off and after boot you can switch on, wait it stop blinking and redo a swipe to right with this switch for pairing
+
 Bluetooth should already partially work. For a better support, e.g. *pairing* and *bonding*, we need the firmware file `BCM4324B3.hcd` in the folder `/lib/firmware/brcm/`.
 - This file can be found in Windows' partition, in the folder `C:\Windows\system32\drivers`.
 - Or, download it from: https://launchpad.net/asust100-ubuntu/+milestone/bluetooth-t100ta
@@ -341,6 +345,10 @@ Add these kernel command-line parameters: `tsc=reliable clocksource=tsc`
 
 # History
 
+##### 20190221
+* Improve mount advices before chrooting
+* Add T100CHI keyboard pairing advices
+
 ##### 20181125
 * Verify the mounts before installing bootloader
 * Add an audio fix: Disable sound over HDMI
@@ -365,3 +373,4 @@ Add these kernel command-line parameters: `tsc=reliable clocksource=tsc`
 
 ##### 20180802
 First version
+


### PR DESCRIPTION
Bonjour,

je tente d'échanger en français, votre profil indique École Centrale de Marseille...
Tout d'abord, un grand merci pour ce guide qui m'a permis de dépoussiérer pour de bon ma T100CHI et la rendre enfin très fonctionnelle avec Linux, j'utilise Debian et j'avais tenté Ubuntu 16.04 et 16.10 mais la connexion au clavier bluetooth n'a jamais été stable malgré les patchs et les compilations de kernel. 

Durant l'installation j'ai cru déceler quelques améliorations pour le guide. Les seules particularités notables de mon installation : T100CHI, Gnome et partition Windows conservée et réduite.
La première serait dans la boucle for, la variable $dir renvoie déjà un slash comme premier caractère.
Ensuite, ma partition ext4 n'était pas montée au moment du lsblk, ce qui m'a valu l'impossibilité de chrooter en suivant les indications pas à pas.
Enfin, je me suis permis d'ajouter un détail concernant la façon de se connecter au clavier bluetooth de la t100CHI.

Je me remets à Git après l'avoir beaucoup délaissé au profit de TFS de par mon environnement professionnel :-/ J'espère avoir suivi les bonnes pratiques pour une première contribution.
Je laisse ce message (roman !?) éditable pour que vous puissiez écrire quelque chose de pertinent et concis, aussi je reste à l'écoute de vos remarques tant pour le guide que pour GitHub.